### PR TITLE
SCSI: add cdb marshalling/unmarshalling be dict driven and datain marsha...

### DIFF
--- a/pyscsi/pyscsi/scsi_cdb_readcapacity10.py
+++ b/pyscsi/pyscsi/scsi_cdb_readcapacity10.py
@@ -17,7 +17,7 @@
 
 from scsi_command import SCSICommand
 from scsi_enum_command import OPCODE
-from pyscsi.utils.converter import decode_bits
+from pyscsi.utils.converter import encode_dict, decode_bits
 
 #
 # SCSI ReadCapacity10 command and definitions
@@ -28,6 +28,9 @@ class ReadCapacity10(SCSICommand):
     """
     A class to hold information from a ReadCapacity(10) command to a scsi device
     """
+    _cdb_bits = {'opcode': [0xff, 0] }
+    _datain_bits = {'returned_lba': [0xffffffff, 0],
+                    'block_length': [0xffffffff, 4], }
 
     def __init__(self, scsi, alloclen=8):
         """
@@ -47,29 +50,47 @@ class ReadCapacity10(SCSICommand):
         :param alloclen: the max number of bytes allocated for the data_in buffer
         :return: a byte array representing a code descriptor block
         """
-        cdb = SCSICommand.init_cdb(OPCODE.READ_CAPACITY_10)
-        return cdb
+        cdb = {'opcode': OPCODE.READ_CAPACITY_10 }
+        return self.marshall_cdb(cdb)
 
     def unmarshall(self):
         """
         Unmarshall the ReadCapacity10 data.
         """
-        _bits = {'returned_lba': [0xffffffff, 0],
-                 'block_length': [0xffffffff, 4], }
-        decode_bits(self.datain, _bits, self.result)
+        self.result = self.unmarshall_datain(self.datain)
 
-    def unmarshall_cdb(self, cdb):
+    @staticmethod
+    def unmarshall_datain(data):
         """
-        method to unmarshall a byte array containing a cdb.
+        Unmarshall the ReadCapacity10 datain.
         """
-        _tmp = {}
-        _bits = {'opcode': [0xff, 0],
-                 'rdprotect': [0xe0, 1],
-                 'dpo': [0x10, 1],
-                 'fua': [0x08, 1],
-                 'rarc': [0x04, 1],
-                 'lba': [0xffffffffffffffff, 2],
-                 'group': [0x1f, 14],
-                 'tl': [0xffffffff, 10], }
-        decode_bits(cdb, _bits, _tmp)
-        return _tmp
+        result = {}
+        decode_bits(data, ReadCapacity10._datain_bits, result)
+        return result
+
+    @staticmethod
+    def marshall_datain(data):
+        """
+        Marshall the ReadCapacity10 datain.
+        """
+        result = bytearray(8)
+        encode_dict(data, ReadCapacity10._datain_bits, result)
+        return result
+
+    @staticmethod
+    def unmarshall_cdb(cdb):
+        """
+        Unmarshall a ReadCapacity10 cdb
+        """
+        result = {}
+        decode_bits(cdb, ReadCapacity10._cdb_bits, result)
+        return result
+
+    @staticmethod
+    def marshall_cdb(cdb):
+        """
+        Marshall a ReadCapacity10 cdb
+        """
+        result = bytearray(10)
+        encode_dict(cdb, ReadCapacity10._cdb_bits, result)
+        return result

--- a/pyscsi/pyscsi/scsi_cdb_readcapacity16.py
+++ b/pyscsi/pyscsi/scsi_cdb_readcapacity16.py
@@ -17,7 +17,7 @@
 
 from scsi_command import SCSICommand
 from scsi_enum_command import OPCODE, SERVICE_ACTION_IN
-from pyscsi.utils.converter import scsi_int_to_ba, decode_bits
+from pyscsi.utils.converter import scsi_int_to_ba, encode_dict, decode_bits
 
 #
 # SCSI ReadCapacity16 command and definitions
@@ -28,6 +28,18 @@ class ReadCapacity16(SCSICommand):
     """
     A class to hold information from a ReadCapacity(16) command to a scsi device
     """
+    _cdb_bits = {'opcode': [0xff, 0],
+                 'service_action': [0x1f, 1],
+                 'alloc_len': [0xffffffff, 10], }
+    _datain_bits = {'returned_lba': [0xffffffffffffffff, 0],
+                    'block_length': [0xffffffff, 8],
+                    'p_type': [0x0e, 12],
+                    'prot_en': [0x01, 12],
+                    'p_i_exponent': [0xf0, 13],
+                    'lbppbe': [0x0f, 13],
+                    'lbpme': [0x80, 14],
+                    'lbprz': [0x40, 14],
+                    'lowest_aligned_lba': [0x3fff, 14], }
 
     def __init__(self, scsi, alloclen=32):
         """
@@ -47,33 +59,50 @@ class ReadCapacity16(SCSICommand):
         :param alloclen: the max number of bytes allocated for the data_in buffer
         :return: a byte array representing a code descriptor block
         """
-        cdb = SCSICommand.init_cdb(OPCODE.SERVICE_ACTION_IN)
-        cdb[1] = SERVICE_ACTION_IN.READ_CAPACITY_16
-        cdb[10:14] = scsi_int_to_ba(alloclen, 4)
-        return cdb
-
-    def unmarshall_cdb(self, cdb):
-        """
-        method to unmarshall a byte array containing a cdb.
-        """
-        _tmp = {}
-        _bits = {'opcode': [0xff, 0],
-                 'service_action': [0x1f, 1],
-                 'alloc_len': [0xffffffff, 10], }
-        decode_bits(cdb, _bits, _tmp)
-        return _tmp
+        cdb = {'opcode': OPCODE.SERVICE_ACTION_IN,
+               'service_action': SERVICE_ACTION_IN.READ_CAPACITY_16,
+               'alloc_len': alloclen
+        }
+        return self.marshall_cdb(cdb)
 
     def unmarshall(self):
         """
         Unmarshall the ReadCapacity16 data.
         """
-        _bits = {'returned_lba': [0xffffffffffffffff, 0],
-                 'block_length': [0xffffffff, 8],
-                 'p_type': [0x0e, 12],
-                 'prot_en': [0x01, 12],
-                 'p_i_exponent': [0xf0, 13],
-                 'lbppbe': [0x0f, 13],
-                 'lbpme': [0x80, 14],
-                 'lbprz': [0x40, 14],
-                 'lowest_aligned_lba': [0x3fff, 14], }
-        decode_bits(self.datain, _bits, self.result)
+        self.result = self.unmarshall_datain(self.datain)
+
+    @staticmethod
+    def unmarshall_datain(data):
+        """
+        Unmarshall the ReadCapacity16 datain.
+        """
+        result = {}
+        decode_bits(data, ReadCapacity16._datain_bits, result)
+        return result
+
+    @staticmethod
+    def marshall_datain(data):
+        """
+        Marshall the ReadCapacity16 datain.
+        """
+        result = bytearray(32)
+        encode_dict(data, ReadCapacity16._datain_bits, result)
+        return result
+
+    @staticmethod
+    def unmarshall_cdb(cdb):
+        """
+        Unmarshall a ReadCapacity16 cdb
+        """
+        result = {}
+        decode_bits(cdb, ReadCapacity16._cdb_bits, result)
+        return result
+
+    @staticmethod
+    def marshall_cdb(cdb):
+        """
+        Marshall a ReadCapacity16 cdb
+        """
+        result = bytearray(16)
+        encode_dict(cdb, ReadCapacity16._cdb_bits, result)
+        return result

--- a/pyscsi/utils/converter.py
+++ b/pyscsi/utils/converter.py
@@ -75,3 +75,26 @@ def decode_bits(data, check_dict, result_dict):
             value >>= 1
         value &= bitmask
         result_dict.update({key: value})
+
+def encode_dict(data_dict, check_dict, result):
+    """
+    encode a dict back into a bytearray
+    """
+    for key in data_dict.iterkeys():
+        value = data_dict[key]
+        bitmask, bytepos = check_dict[key]
+
+        _num = 1
+        _bm = bitmask
+        while _bm > 0xff:
+            _bm >>= 8
+            _num += 1
+
+        _bm = bitmask
+        while not _bm & 0x01:
+            _bm >>= 1
+            value <<= 1
+
+        v = scsi_int_to_ba(value, _num)
+        for i in range(len(v)):
+            result[bytepos + i] ^= v[i]

--- a/tests/test_cdb_readcapacity10.py
+++ b/tests/test_cdb_readcapacity10.py
@@ -3,6 +3,7 @@
 
 from pyscsi.pyscsi.scsi import SCSI
 from pyscsi.pyscsi.scsi_enum_command import OPCODE
+from pyscsi.pyscsi.scsi_cdb_readcapacity10 import ReadCapacity10
 
 
 class MockReadCapacity10(object):
@@ -19,6 +20,9 @@ def main():
     assert cdb[1:10] == bytearray(9)
     cdb = r.unmarshall_cdb(cdb)
     assert cdb['opcode'] == OPCODE.READ_CAPACITY_10
+
+    d = ReadCapacity10.unmarshall_cdb(ReadCapacity10.marshall_cdb(cdb))
+    assert d == cdb
 
 if __name__ == "__main__":
     main()

--- a/tests/test_cdb_readcapacity16.py
+++ b/tests/test_cdb_readcapacity16.py
@@ -4,6 +4,7 @@
 from pyscsi.pyscsi.scsi import SCSI
 from pyscsi.utils.converter import scsi_ba_to_int
 from pyscsi.pyscsi.scsi_enum_command import OPCODE, SERVICE_ACTION_IN
+from pyscsi.pyscsi.scsi_cdb_readcapacity16 import ReadCapacity16
 
 
 class MockReadCapacity16(object):
@@ -25,6 +26,9 @@ def main():
     assert cdb['opcode'] == OPCODE.SERVICE_ACTION_IN
     assert cdb['service_action'] == SERVICE_ACTION_IN.READ_CAPACITY_16
     assert cdb['alloc_len'] == 37
+
+    d = ReadCapacity16.unmarshall_cdb(ReadCapacity16.marshall_cdb(cdb))
+    assert d == cdb
 
 if __name__ == "__main__":
     main()

--- a/tests/test_unmarshall_readcapacity10.py
+++ b/tests/test_unmarshall_readcapacity10.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 from pyscsi.pyscsi.scsi import SCSI
+from pyscsi.pyscsi.scsi_cdb_readcapacity10 import ReadCapacity10
 
 
 class MockReadCapacity10(object):
@@ -18,6 +19,9 @@ def main():
     i = s.readcapacity10().result
     assert i['returned_lba'] == 65536
     assert i['block_length'] == 4096
+
+    d = ReadCapacity10.unmarshall_datain(ReadCapacity10.marshall_datain(i))
+    assert d == i
 
 if __name__ == "__main__":
     main()

--- a/tests/test_unmarshall_readcapacity16.py
+++ b/tests/test_unmarshall_readcapacity16.py
@@ -2,6 +2,7 @@
 # coding: utf-8
 
 from pyscsi.pyscsi.scsi import SCSI
+from pyscsi.pyscsi.scsi_cdb_readcapacity16 import ReadCapacity16
 
 
 class MockReadCapacity16(object):
@@ -29,6 +30,9 @@ def main():
     assert i['lbpme'] == 1
     assert i['lbprz'] == 1
     assert i['lowest_aligned_lba'] == 8193
+
+    d = ReadCapacity16.unmarshall_datain(ReadCapacity16.marshall_datain(i))
+    assert d == i
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
...lling

ReadCapacity10/16

Add a helper function encode_dict that is the inverse of decode_bits.
This function expects the same dict containing the schema as decode_bits
and takes a dict containing values as input marshalls this dict into a
bytearray. This is the opposite of decode_bits which takes a bytearray
as input and unmarshalls it into a dict.

Add static methods for cdb marshalling and unmarshalling the cdb.
Make cdb marshalling dict driven instead of manual marshalling of the fields
we used before.

Add static methods for marshalling and unmarshalling of the data-in buffer
for these commands.

Add tests to verify marshalling and test that
<dict> == unmarshall_datain(marshall_datain(<dict>))

Signed-off-by: Ronnie Sahlberg <ronniesahlberg@gmail.com>