### PR TITLE
Allow SGIO on non-/dev/sg devices, improve debuggability

### DIFF
--- a/linux_sgio/sgiomodule.c
+++ b/linux_sgio/sgiomodule.c
@@ -238,6 +238,11 @@ static PyObject *linux_sgio_execute( PyObject *self, PyObject *args )
     io_hdr.dxfer_len       = datain_buf.len;
     io_hdr.dxferp          = datain_buf.buf;
     }
+  else
+    {
+    PyErr_SetString( SGIOError, "No input or output buffer provided." );
+    return( NULL );
+    }
 
   io_hdr.sbp       = sense_buf.buf;
   io_hdr.mx_sb_len = sense_buf.len;

--- a/linux_sgio/sgiomodule.c
+++ b/linux_sgio/sgiomodule.c
@@ -221,10 +221,15 @@ static PyObject *linux_sgio_execute( PyObject *self, PyObject *args )
     return( NULL );
   if( PyObject_GetBuffer( cdb_arg, &cdb_buf, PyBUF_WRITABLE ) < 0 )
     return( NULL );
-  if( PyObject_GetBuffer( dataout_arg, &dataout_buf, PyBUF_WRITABLE ) < 0 )
+
+  if( PyObject_GetBuffer( dataout_arg, &dataout_buf, PyBUF_SIMPLE ) < 0 )
     return( NULL );
-  if( PyObject_GetBuffer( datain_arg, &datain_buf, PyBUF_WRITABLE ) < 0 )
+
+  /* We need either dataout or datain, we don't need both. */
+  if ( dataout_buf.len <= 0 &&
+       PyObject_GetBuffer( datain_arg, &datain_buf, PyBUF_WRITABLE ) < 0 )
     return( NULL );
+
   if( PyObject_GetBuffer( sense_arg, &sense_buf, PyBUF_WRITABLE ) < 0 )
     return( NULL );
 
@@ -241,8 +246,7 @@ static PyObject *linux_sgio_execute( PyObject *self, PyObject *args )
     io_hdr.dxfer_len       = dataout_buf.len;
     io_hdr.dxferp          = dataout_buf.buf;
     }
-
-  if( datain_buf.len )
+  else if( datain_buf.len )
     {
     io_hdr.dxfer_direction = SG_DXFER_FROM_DEV;
     io_hdr.dxfer_len       = datain_buf.len;

--- a/linux_sgio/sgiomodule.c
+++ b/linux_sgio/sgiomodule.c
@@ -111,20 +111,6 @@
 char             bufr[bSIZE];
 static PyObject *SGIOError;
 
-/* adding some stuff from the Python Docs to make this module ready for
- * Python 3. This should be reviewed by the C Guys in the Project
- */
-struct module_state {
-    PyObject *SGIOError;
-};
-
-#if PY_MAJOR_VERSION >= 3
-#define GETSTATE(m) ((struct module_state*)PyModule_GetState(m))
-#else
-#define GETSTATE(m) (&_state)
-static struct module_state _state;
-#endif
-
 /* -------------------------------------------------------------------------- **
  * Static functions:
  */
@@ -330,29 +316,13 @@ static PyObject *linux_sgio_close( PyObject *self, PyObject *args )
 
 #if PY_MAJOR_VERSION >= 3
 
-  static int linux_sgio_traverse(PyObject *m, visitproc visit, void *arg)
-  {
-    Py_VISIT(GETSTATE(m)->SGIOError);
-    return 0;
-  }
-
-  static int linux_sgio_clear(PyObject *m)
-  {
-    Py_CLEAR(GETSTATE(m)->SGIOError);
-    return 0;
-  }
-
   static struct PyModuleDef moduledef =
     {
         PyModuleDef_HEAD_INIT,
         "linux_sgio",
         NULL,
-        sizeof(struct module_state),
+	-1,
         SGIOMethods,
-        NULL,
-        linux_sgio_traverse,
-        linux_sgio_clear,
-        NULL
     };
 
   #define INITERROR return NULL
@@ -378,10 +348,13 @@ static PyObject *linux_sgio_close( PyObject *self, PyObject *args )
 #endif
       if( module == NULL)
         INITERROR;
-      struct module_state *st = GETSTATE(module);
 
-      st->SGIOError = PyErr_NewException( "linux_sgio.error", NULL, NULL );
-    if (st->SGIOError == NULL)
+      SGIOError = PyErr_NewException( "linux_sgio.SGIOError", NULL, NULL );
+      Py_INCREF(SGIOError);
+      if ( PyModule_AddObject(module, "SGIOError", SGIOError) == -1 )
+	INITERROR;
+
+    if (SGIOError == NULL)
     {
         Py_DECREF(module);
         INITERROR;

--- a/pyscsi/pyscsi/scsi_cdb_read10.py
+++ b/pyscsi/pyscsi/scsi_cdb_read10.py
@@ -37,6 +37,9 @@ class Read10(SCSICommand):
                  'tl': [0xffff, 7], }
 
     def __init__(self, scsi, lba, tl, **kwargs):
+        if scsi.blocksize == 0:
+            raise SCSICommand.MissingBlocksizeException
+
         SCSICommand.__init__(self, scsi, 0, scsi.blocksize * tl)
         self.cdb = self.build_cdb(lba, tl, **kwargs)
         self.execute()

--- a/pyscsi/pyscsi/scsi_cdb_read12.py
+++ b/pyscsi/pyscsi/scsi_cdb_read12.py
@@ -37,6 +37,9 @@ class Read12(SCSICommand):
                  'group': [0x1f, 10], }
 
     def __init__(self, scsi, lba, tl, **kwargs):
+        if scsi.blocksize == 0:
+            raise SCSICommand.MissingBlocksizeException
+
         SCSICommand.__init__(self, scsi, 0, scsi.blocksize * tl)
         self.cdb = self.build_cdb(lba, tl, **kwargs)
         self.execute()

--- a/pyscsi/pyscsi/scsi_cdb_read16.py
+++ b/pyscsi/pyscsi/scsi_cdb_read16.py
@@ -37,6 +37,9 @@ class Read16(SCSICommand):
                  'tl': [0xffffffff, 10], }
 
     def __init__(self, scsi, lba, tl, **kwargs):
+        if scsi.blocksize == 0:
+            raise SCSICommand.MissingBlocksizeException
+
         SCSICommand.__init__(self, scsi, 0, scsi.blocksize * tl)
         self.cdb = self.build_cdb(lba, tl, **kwargs)
         self.execute()

--- a/pyscsi/pyscsi/scsi_device.py
+++ b/pyscsi/pyscsi/scsi_device.py
@@ -15,6 +15,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+import sys
+
 import pyscsi.pyscsi.scsi_enum_command as scsi_enum_command
 
 from pyscsi.pyscsi.scsi_exception import SCSIDeviceCommandExceptionMeta as ExMETA
@@ -62,6 +64,9 @@ class SCSIDevice(_new_base_class):
         elif _have_linux_sgio and device[:5] == '/dev/':
             self._is_linux_sgio = True
             self._fd = linux_sgio.open(device, bool(readwrite))
+        else:
+            print('No backend available for "%s", commands will not execute.' % device,
+                  file=sys.stderr)
 
     def execute(self, cdb, dataout, datain, sense):
         """

--- a/pyscsi/pyscsi/scsi_device.py
+++ b/pyscsi/pyscsi/scsi_device.py
@@ -59,7 +59,7 @@ class SCSIDevice(_new_base_class):
             libiscsi.iscsi_full_connect_sync(self._iscsi, self._iscsi_url.portal, self._iscsi_url.lun)
 
             self._is_libiscsi = True
-        elif _have_linux_sgio and device[:7] == '/dev/sg':
+        elif _have_linux_sgio and device[:5] == '/dev/':
             self._is_linux_sgio = True
             self._fd = linux_sgio.open(device, bool(readwrite))
 

--- a/pyscsi/pyscsi/scsi_exception.py
+++ b/pyscsi/pyscsi/scsi_exception.py
@@ -27,10 +27,14 @@ class SCSICommandExceptionMeta(type):
         class CommandNotImplemented(Exception):
             pass
 
+        class MissingBlocksizeException(Exception):
+            pass
+
         class OpcodeException(Exception):
             pass
 
         attributes.update({'CommandNotImplemented': CommandNotImplemented})
+        attributes.update({'MissingBlocksizeException': MissingBlocksizeException})
         attributes.update({'OpcodeException': OpcodeException})
 
         return type.__new__(mcs, cls, bases, attributes)


### PR DESCRIPTION
I'd like to use your library for my glucometerutils, as LifeScan makes devices that use "LBA registers" for communication.

While trying it out I realize that the Linux SGIO backend does not work without /dev/sg (which are now unnecessary), but it took me a while to debug it, so I fixed it and made it clear if that's the problem.
