### PR TITLE
scsi_cdb_read*: raise MissingBlocksizeException if blocksize is missing.

### DIFF
--- a/pyscsi/pyscsi/scsi_cdb_read10.py
+++ b/pyscsi/pyscsi/scsi_cdb_read10.py
@@ -37,6 +37,9 @@ class Read10(SCSICommand):
                  'tl': [0xffff, 7], }
 
     def __init__(self, scsi, lba, tl, **kwargs):
+        if scsi.blocksize == 0:
+            raise SCSICommand.MissingBlocksizeException
+
         SCSICommand.__init__(self, scsi, 0, scsi.blocksize * tl)
         self.cdb = self.build_cdb(lba, tl, **kwargs)
         self.execute()

--- a/pyscsi/pyscsi/scsi_cdb_read12.py
+++ b/pyscsi/pyscsi/scsi_cdb_read12.py
@@ -37,6 +37,9 @@ class Read12(SCSICommand):
                  'group': [0x1f, 10], }
 
     def __init__(self, scsi, lba, tl, **kwargs):
+        if scsi.blocksize == 0:
+            raise SCSICommand.MissingBlocksizeException
+
         SCSICommand.__init__(self, scsi, 0, scsi.blocksize * tl)
         self.cdb = self.build_cdb(lba, tl, **kwargs)
         self.execute()

--- a/pyscsi/pyscsi/scsi_cdb_read16.py
+++ b/pyscsi/pyscsi/scsi_cdb_read16.py
@@ -37,6 +37,9 @@ class Read16(SCSICommand):
                  'tl': [0xffffffff, 10], }
 
     def __init__(self, scsi, lba, tl, **kwargs):
+        if scsi.blocksize == 0:
+            raise SCSICommand.MissingBlocksizeException
+
         SCSICommand.__init__(self, scsi, 0, scsi.blocksize * tl)
         self.cdb = self.build_cdb(lba, tl, **kwargs)
         self.execute()

--- a/pyscsi/pyscsi/scsi_exception.py
+++ b/pyscsi/pyscsi/scsi_exception.py
@@ -27,10 +27,14 @@ class SCSICommandExceptionMeta(type):
         class CommandNotImplemented(Exception):
             pass
 
+        class MissingBlocksizeException(Exception):
+            pass
+
         class OpcodeException(Exception):
             pass
 
         attributes.update({'CommandNotImplemented': CommandNotImplemented})
+        attributes.update({'MissingBlocksizeException': MissingBlocksizeException})
         attributes.update({'OpcodeException': OpcodeException})
 
         return type.__new__(mcs, cls, bases, attributes)


### PR DESCRIPTION
Without a blocksize, no read operation can be executed as no transfer
length is provided.