### PR TITLE
Allow non-sg* devices and raise exception if missing backend.

### DIFF
--- a/pyscsi/pyscsi/scsi_device.py
+++ b/pyscsi/pyscsi/scsi_device.py
@@ -15,6 +15,8 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>.
+import sys
+
 import pyscsi.pyscsi.scsi_enum_command as scsi_enum_command
 
 from pyscsi.pyscsi.scsi_exception import SCSIDeviceCommandExceptionMeta as ExMETA
@@ -62,6 +64,8 @@ class SCSIDevice(_new_base_class):
         elif _have_linux_sgio and device[:5] == '/dev/':
             self._is_linux_sgio = True
             self._fd = linux_sgio.open(device, bool(readwrite))
+        else:
+            raise NotImplementedError('No backend implemented for %s' % device)
 
     def execute(self, cdb, dataout, datain, sense):
         """

--- a/pyscsi/pyscsi/scsi_device.py
+++ b/pyscsi/pyscsi/scsi_device.py
@@ -59,7 +59,7 @@ class SCSIDevice(_new_base_class):
             libiscsi.iscsi_full_connect_sync(self._iscsi, self._iscsi_url.portal, self._iscsi_url.lun)
 
             self._is_libiscsi = True
-        elif _have_linux_sgio and device[:7] == '/dev/sg':
+        elif _have_linux_sgio and device[:5] == '/dev/':
             self._is_linux_sgio = True
             self._fd = linux_sgio.open(device, bool(readwrite))
 


### PR DESCRIPTION
This saves a lot of time debugging. You can still use the SCSI classes without a backend, but don't insist you can execute a command, if no backend is known.