### PR TITLE
Fix linux_sgio to actually work for read/write transfers

### DIFF
--- a/linux_sgio/__init__.py
+++ b/linux_sgio/__init__.py
@@ -1,1 +1,1 @@
-from .linux_sgio import open, execute, close
+from .linux_sgio import *

--- a/linux_sgio/sgiomodule.c
+++ b/linux_sgio/sgiomodule.c
@@ -197,19 +197,15 @@ static PyObject *linux_sgio_execute( PyObject *self, PyObject *args )
   PyObject   *cdb_arg, *dataout_arg, *datain_arg, *sense_arg;
   Py_buffer   cdb_buf,  dataout_buf,  datain_buf,  sense_buf;
   sg_io_hdr_t io_hdr;
-  int         i;
+  int         i, dxfer;
 
   /* Parse and exctract the Python input parameters.
    *  See the discussion here:  https://docs.python.org/2/c-api/buffer.html
    */
-  if( !PyArg_ParseTuple( args, "iOOOO:sgio_execute", &i,
+  if( !PyArg_ParseTuple( args, "iiOOOO:sgio_execute", &i, &dxfer,
                          &cdb_arg, &dataout_arg, &datain_arg, &sense_arg ) )
     return( NULL );
   if( PyObject_GetBuffer( cdb_arg, &cdb_buf, PyBUF_WRITABLE ) < 0 )
-    return( NULL );
-  if( PyObject_GetBuffer( dataout_arg, &dataout_buf, PyBUF_WRITABLE ) < 0 )
-    return( NULL );
-  if( PyObject_GetBuffer( datain_arg, &datain_buf, PyBUF_WRITABLE ) < 0 )
     return( NULL );
   if( PyObject_GetBuffer( sense_arg, &sense_buf, PyBUF_WRITABLE ) < 0 )
     return( NULL );
@@ -219,20 +215,21 @@ static PyObject *linux_sgio_execute( PyObject *self, PyObject *args )
   io_hdr.interface_id    = 'S';
   io_hdr.cmdp            = cdb_buf.buf;
   io_hdr.cmd_len         = cdb_buf.len;
-  io_hdr.dxfer_direction = 0;
+  io_hdr.dxfer_direction = dxfer;
 
-  if( dataout_buf.len )
+  if( dxfer == SG_DXFER_TO_DEV )
     {
-    io_hdr.dxfer_direction = SG_DXFER_TO_DEV;
-    io_hdr.dxfer_len       = dataout_buf.len;
-    io_hdr.dxferp          = dataout_buf.buf;
+      if ( PyObject_GetBuffer( dataout_arg, &dataout_buf, PyBUF_WRITABLE ) < 0 )
+	return( NULL );
+      io_hdr.dxfer_len       = dataout_buf.len;
+      io_hdr.dxferp          = dataout_buf.buf;
     }
-
-  if( datain_buf.len )
+  else if ( dxfer == SG_DXFER_FROM_DEV )
     {
-    io_hdr.dxfer_direction = SG_DXFER_FROM_DEV;
-    io_hdr.dxfer_len       = datain_buf.len;
-    io_hdr.dxferp          = datain_buf.buf;
+      if( PyObject_GetBuffer( datain_arg, &datain_buf, PyBUF_WRITABLE ) < 0 )
+	return( NULL );
+      io_hdr.dxfer_len       = datain_buf.len;
+      io_hdr.dxferp          = datain_buf.buf;
     }
 
   io_hdr.sbp       = sense_buf.buf;
@@ -348,6 +345,16 @@ static PyObject *linux_sgio_close( PyObject *self, PyObject *args )
       SGIOError = PyErr_NewException( "linux_sgio.SGIOError", NULL, NULL );
       Py_INCREF(SGIOError);
       if ( PyModule_AddObject(module, "SGIOError", SGIOError) == -1 )
+	INITERROR;
+
+      /* Define some of the SGIO constants for use in the Python code. */
+      if ( PyModule_AddIntConstant(module, "DXFER_NONE", SG_DXFER_NONE) < 0 )
+	INITERROR;
+      if ( PyModule_AddIntConstant(module, "DXFER_TO_DEV", SG_DXFER_TO_DEV) < 0 )
+	INITERROR;
+      if ( PyModule_AddIntConstant(module, "DXFER_FROM_DEV", SG_DXFER_FROM_DEV) < 0 )
+	INITERROR;
+      if ( PyModule_AddIntConstant(module, "DXFER_TO_FROM_DEV", SG_DXFER_TO_FROM_DEV) < 0 )
 	INITERROR;
 
     if (SGIOError == NULL)

--- a/linux_sgio/sgiomodule.c
+++ b/linux_sgio/sgiomodule.c
@@ -219,7 +219,7 @@ static PyObject *linux_sgio_execute( PyObject *self, PyObject *args )
 
   if( dxfer == SG_DXFER_TO_DEV )
     {
-      if ( PyObject_GetBuffer( dataout_arg, &dataout_buf, PyBUF_WRITABLE ) < 0 )
+      if ( PyObject_GetBuffer( dataout_arg, &dataout_buf, PyBUF_SIMPLE ) < 0 )
 	return( NULL );
       io_hdr.dxfer_len       = dataout_buf.len;
       io_hdr.dxferp          = dataout_buf.buf;

--- a/pyscsi/pyscsi/scsi_device.py
+++ b/pyscsi/pyscsi/scsi_device.py
@@ -101,7 +101,15 @@ class SCSIDevice(_new_base_class):
             raise self.SCSISGIOError
 
         elif self.isLinuxSGIO:
-            status = linux_sgio.execute(self._fd, cdb, dataout, datain, sense)
+            _dir = linux_sgio.DXFER_NONE
+            if len(datain) and len(dataout):
+                raise NotImplemented('Indirect IO is not supported')
+            elif len(datain):
+                _dir = linux_sgio.DXFER_FROM_DEV
+            elif len(dataout):
+                _dir = linux_sgio.DXFER_TO_DEV
+
+            status = linux_sgio.execute(self._fd, _dir, cdb, dataout, datain, sense)
             if status == scsi_enum_command.SCSI_STATUS.CHECK_CONDITION:
                 raise self.CheckCondition(sense)
             if status == scsi_enum_command.SCSI_STATUS.SGIO_ERROR:


### PR DESCRIPTION
This time it also works correctly for no-transfer commands like TEST UNIT READY.

The python code handles almost the same way as the iscsi counterpart does. It could easily be refactored a bit to use the same logic behind the scenes, but for now I think it'll do.

Tested with `inquiry.py`, which issues TEST UNIT READY and INQUIRY ­(a read command), and with my own PoC which includes WRITE and READ commands.