### PR TITLE
Increase ioctl timeout

### DIFF
--- a/linux_sgio/sgiomodule.c
+++ b/linux_sgio/sgiomodule.c
@@ -235,7 +235,7 @@ static PyObject *linux_sgio_execute( PyObject *self, PyObject *args )
 
   io_hdr.sbp       = sense_buf.buf;
   io_hdr.mx_sb_len = sense_buf.len;
-  io_hdr.timeout   = 20000;
+  io_hdr.timeout   = 1800000;
 
   /* Call ioctl(2).
    *  Raise a Python exception if the call fails.


### PR DESCRIPTION
AS-IS timeout is too short compared to several tape drive technical specs. Increase it to 30 minutes according to mtx codebase.

For reference:
* Recommend timeout of load/unload operation is 14 minutes in HPE StoreEver LTO-8 Ultrium Tape Drives Technical Reference Manual Volume 2 Software Integration Guide.  
* Max timeout in mtx is 30 minutes https://github.com/hrchu/mtx/blob/master/mtx/mtxl.cpp#L377